### PR TITLE
Hyperlink contact names to personal websites

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,12 +849,12 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
         </h2>
         <p>
           For high-level discussions, funding opportunities, or collaboration inquiries, please reach out to the project supervisor, 
-          <strong>Professor Vladimir Filkov</strong> 
+          <strong><a href="https://www.cs.ucdavis.edu/~filkov/" target="_blank">Professor Vladimir Filkov</a></strong>
           (<a href="mailto:vfilkov@ucdavis.edu">vfilkov@ucdavis.edu</a>).
         </p>
         <p>
           For technical questions, bug reports, or concerns regarding the codebase, please contact the current tech lead, 
-          <strong>Nafiz Imtiaz Khan</strong> 
+          <strong><a href="https://nafiz43.github.io/portfolio/" target="_blank">Nafiz Imtiaz Khan</a></strong>
           (<a href="mailto:nikhan@ucdavis.edu">nikhan@ucdavis.edu</a>).
         </p>
         <p>


### PR DESCRIPTION
## Summary
- Link Professor Vladimir Filkov's name in the Contact section to his personal website
- Link Nafiz Imtiaz Khan's name in the Contact section to his personal website

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7a8c6294832a860344e2b119ec95