### PR TITLE
Add link to server capabilities page on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,20 @@
   </div>
 </section>
 
+<section class="section">
+  <div class="container is-max-desktop">
+    <div class="columns is-centered">
+      <div class="column is-four-fifths">
+        <div class="content has-text-justified">
+          <p><strong>Current Hosted Server Capabilities</strong></p>
+          <p>
+            OSSPREY is currently hosted on one of our lab servers. The specifications of this server can be found at the following link (<a href="current_server_capabilities.html">current hosted server capabilities</a>). Due to current server limitations, OSSPREY may not be able to process repositories with more than 5,000 commits or 300 contributors.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
 <section class="section">
   <div class="container is-max-desktop">


### PR DESCRIPTION
## Summary
- replace the homepage button with a dedicated section linking to the new server capabilities page and explaining current hosting limits
