### PR TITLE
Add CITATION file and site instructions for citing OSSPREY

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+title: "OSSPREY: Open Source Software PRojEct sustainabilitY tracker"
+message: "If you use OSSPREY in your work, please cite it using the metadata from this file."
+type: software
+abstract: |
+  OSSPREY helps researchers and practitioners monitor and improve the sustainability of open
+  source software projects by combining socio-technical network analysis with machine learning
+  driven forecasting and actionable recommendations.
+authors:
+  - family-names: Khan
+    given-names: Nafiz Imtiaz
+  - family-names: Soni
+    given-names: Priyal
+  - family-names: Ashok
+    given-names: Arjun
+  - family-names: Kashyap
+    given-names: Sankalp
+  - family-names: Filkov
+    given-names: Vladimir
+version: 1.0.0
+date-released: 2024-10-01
+repository-code: https://github.com/OSS-PREY/OSSPREY-Website
+url: https://ossprey.netlify.app
+preferred-citation:
+  type: software
+  title: "OSSPREY: Open Source Software PRojEct sustainabilitY tracker"
+  authors:
+    - family-names: Khan
+      given-names: Nafiz Imtiaz
+    - family-names: Soni
+      given-names: Priyal
+    - family-names: Ashok
+      given-names: Arjun
+    - family-names: Kashyap
+      given-names: Sankalp
+    - family-names: Filkov
+      given-names: Vladimir
+  version: 1.0.0
+  date-released: 2024-10-01
+  repository-code: https://github.com/OSS-PREY/OSSPREY-Website
+  url: https://ossprey.netlify.app
+  abstract: |
+    OSSPREY provides sustainability forecasting and evidence-based interventions for open
+    source software projects.

--- a/index.html
+++ b/index.html
@@ -813,6 +813,25 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
   </div>
 </section>
 
+<section class="section" id="Citation">
+  <div class="container is-max-desktop">
+    <div class="columns is-centered">
+      <div class="column is-four-fifths">
+        <h2 class="title is-3 has-text-centered">
+          Cite OSSPREY
+        </h2>
+        <p>
+          Cite the OSSPREY tool using the metadata in the <code>CITATION.cff</code> file at the root of the repository. Most reference managers can import the file directly, and the snippet below offers a quick textual reference.
+        </p>
+        <div class="box has-text-left">
+          <p class="mb-2"><strong>Quick citation format:</strong></p>
+<pre><code>Khan, N. I., Soni, P., Ashok, A., Kashyap, S., &amp; Filkov, V. (2024). OSSPREY: Open Source Software PRojEct sustainabilitY tracker (Version 1.0.0) [Computer software]. https://github.com/OSS-PREY/OSSPREY-Website</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="section" id="License">
   <div class="container is-max-desktop">
     <div class="columns is-centered">


### PR DESCRIPTION
## Summary
- add a CITATION.cff file with structured metadata for OSSPREY
- update the website to highlight how to cite the project and provide a quick reference snippet

## Testing
- not run (static content change)