### PR TITLE
Integrate hosted view counter API across pages

### DIFF
--- a/blog_post.html
+++ b/blog_post.html
@@ -141,5 +141,9 @@
 
     <p>Built by the DECAL Lab at UC Davis, OSSPREY is paving the way for data-driven, evidence-based OSS sustainability. Empower your project with proactive insights today.</p>
   </div>
+  <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
+  </footer>
+  <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey-backend.onrender.com"></script>
 </body>
 </html>

--- a/current_server_capabilities.html
+++ b/current_server_capabilities.html
@@ -144,5 +144,9 @@
     <p class="note">These specifications capture the configuration of the local server powering our hosted environment.</p>
     <p>Return to the <a href="blog_post.html">OSSPREY blog post</a> to learn how these capabilities accelerate our forecasting pipeline.</p>
   </div>
+  <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
+  </footer>
+  <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey-backend.onrender.com"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -949,14 +949,14 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
           <p class="is-size-7 has-text-grey">
             <a href="terms-of-service.html">Terms of Service</a>
           </p>
-          <p class="is-size-7 has-text-grey"><b>Website Views:</b> <span id="view-count">0</span></p>
+          <p class="is-size-7 has-text-grey"><b>Website Views:</b> <span id="view-count">--</span></p>
         </div>
       </div>
     </div>
   </div>
 </footer>
 
-<script src="./static/js/view-counter.js"></script>
+<script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey-backend.onrender.com"></script>
 
 </body>
 </html>

--- a/static/js/view-counter.js
+++ b/static/js/view-counter.js
@@ -1,48 +1,166 @@
+const PLACEHOLDER_BASES = new Set([
+  'https://your-backend-domain.com',
+  'http://your-backend-domain.com',
+  'https://example.com',
+  'http://example.com',
+  'null'
+]);
+
+const scriptElement = document.currentScript || document.getElementById('view-counter-script');
+
+function normalizeBase(base) {
+  if (typeof base !== 'string') {
+    return '';
+  }
+  return base.trim().replace(/\/+$/, '');
+}
+
+function collectConfiguredBases() {
+  const bases = [];
+
+  const addBase = (value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+    const trimmed = value.trim();
+    if (!trimmed || PLACEHOLDER_BASES.has(trimmed)) {
+      return;
+    }
+    bases.push(normalizeBase(trimmed));
+  };
+
+  if (scriptElement && scriptElement.dataset) {
+    addBase(scriptElement.dataset.apiBase);
+  }
+
+  if (typeof window !== 'undefined') {
+    addBase(window.OSSPREY_VIEW_COUNTER_API_BASE);
+
+    if (window.location && window.location.origin) {
+      addBase(window.location.origin);
+    }
+  }
+
+  const metaBase = document
+    .querySelector('meta[name="ossprey-view-counter-api-base"]')
+    ?.getAttribute('content');
+  addBase(metaBase);
+
+  const uniqueBases = Array.from(new Set(bases.filter((base) => base !== '')));
+  uniqueBases.push('');
+  return uniqueBases;
+}
+
+const API_BASES = collectConfiguredBases();
+
+function joinUrl(base, path) {
+  if (!base) {
+    return path;
+  }
+
+  const normalizedBase = base.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+async function fetchWithFallback(path, options) {
+  let lastError = null;
+
+  for (const base of API_BASES) {
+    const url = joinUrl(base, path);
+
+    try {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        lastError = new Error(`Request to ${url} failed with status ${response.status}`);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('All view counter API requests failed.');
+}
+
+function updateViewCountElement(value) {
+  const element = document.getElementById('view-count');
+  if (!element) {
+    return;
+  }
+  element.textContent = value;
+}
+
 async function recordView() {
   try {
-    await fetch('/api/record_view', { method: 'POST' });
+    await fetchWithFallback('/api/record_view', {
+      method: 'POST',
+      mode: 'cors'
+    });
   } catch (err) {
     console.error('record_view endpoint failed', err);
   }
 }
 
-async function fetchViewCount() {
-  let count = 0;
-  try {
-    const response = await fetch('/api/view_count');
-    if (response.ok) {
-      const text = await response.text();
-      try {
-        const data = JSON.parse(text);
-        if (typeof data === 'number') {
-          count = data;
-        } else if (data.count !== undefined) {
-          count = data.count;
-        } else if (data.view_count !== undefined) {
-          count = data.view_count;
-        } else {
-          const values = Object.values(data).filter(v => typeof v === 'number');
-          if (values.length > 0) {
-            count = values[0];
-          }
-        }
-      } catch (e) {
-        const parsed = parseInt(text, 10);
-        if (!isNaN(parsed)) {
-          count = parsed;
-        }
-      }
+async function parseCountResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    const data = await response.json();
+
+    if (typeof data === 'number') {
+      return data;
     }
+
+    if (data && typeof data.count === 'number') {
+      return data.count;
+    }
+
+    if (data && typeof data.view_count === 'number') {
+      return data.view_count;
+    }
+
+    const numericValue = Object.values(data).find((value) => typeof value === 'number');
+    if (typeof numericValue === 'number') {
+      return numericValue;
+    }
+  }
+
+  const text = await response.text();
+  const parsed = parseInt(text, 10);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error('Unable to parse view count from response.');
+}
+
+async function fetchViewCount() {
+  try {
+    const response = await fetchWithFallback('/api/view_count', {
+      method: 'GET',
+      mode: 'cors'
+    });
+    const count = await parseCountResponse(response);
+    updateViewCountElement(count.toLocaleString());
   } catch (err) {
     console.error('view_count endpoint failed', err);
-  }
-  const el = document.getElementById('view-count');
-  if (el) {
-    el.textContent = count;
+    updateViewCountElement('N/A');
   }
 }
 
+async function initializeViewCounter() {
+  const element = document.getElementById('view-count');
+  if (!element) {
+    return;
+  }
+
+  updateViewCountElement('...');
+  await recordView();
+  await fetchViewCount();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  recordView();
-  fetchViewCount();
+  initializeViewCounter();
 });

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -71,5 +71,9 @@
 
     <p><a href="index.html">Return to Home</a></p>
   </div>
+  <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
+  </footer>
+  <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey-backend.onrender.com"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance the view counter script to call the hosted API with fallback handling and friendly UI updates
- surface the website view total in the footer of the home, blog, terms of service, and server capability pages using the shared script

## Testing
- not run (static site changes)