### PR TITLE
Display backend user count beside OSSPREY views

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,7 +949,11 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
           <p class="is-size-7 has-text-grey">
             <a href="terms-of-service.html">Terms of Service</a>
           </p>
-          <p class="is-size-16 has-text-grey"><b>OSSPREY Views:</b> <span id="view-count">--</span></p>
+          <p class="is-size-16 has-text-grey">
+            <b>OSSPREY Views:</b> <span id="view-count">--</span>
+            <span class="mx-2">|</span>
+            <b>Users:</b> <span id="user-count">--</span>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a "Users" counter to the footer so the user total appears next to the OSSPREY view count
- update the view counter script to fetch the `/api/users` endpoint, compute the unique email total, and render it in the footer

## Testing
- Not run (static site changes)