### PR TITLE
Add dynamic current year to footer copyright notices

### DIFF
--- a/blog_post.html
+++ b/blog_post.html
@@ -142,6 +142,7 @@
     <p>Built by the DECAL Lab at UC Davis, OSSPREY is paving the way for data-driven, evidence-based OSS sustainability. Empower your project with proactive insights today.</p>
   </div>
   <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p>© <span data-current-year></span> DECAL Lab, UC Davis. Released under MIT License.</p>
     <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
   </footer>
   <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey.ngrok.app"></script>

--- a/current_server_capabilities.html
+++ b/current_server_capabilities.html
@@ -145,6 +145,7 @@
     <p>Return to the <a href="blog_post.html">OSSPREY blog post</a> to learn how these capabilities accelerate our forecasting pipeline.</p>
   </div>
   <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p>© <span data-current-year></span> DECAL Lab, UC Davis. Released under MIT License.</p>
     <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
   </footer>
   <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey.ngrok.app"></script>

--- a/index.html
+++ b/index.html
@@ -953,6 +953,9 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
           <p class="is-size-7 has-text-grey">
             <a href="terms-of-service.html">Terms of Service</a>
           </p>
+          <p class="is-size-7 has-text-grey">
+            © <span data-current-year></span> DECAL Lab, UC Davis. Released under MIT License.
+          </p>
           <p class="is-size-16 has-text-grey">
             <b>OSSPREY Views:</b> <span id="view-count">--</span>
             <span class="mx-2">|</span>

--- a/static/js/view-counter.js
+++ b/static/js/view-counter.js
@@ -188,6 +188,18 @@ async function fetchUserCount() {
   }
 }
 
+function updateCurrentYear() {
+  const yearElements = document.querySelectorAll('[data-current-year]');
+  if (!yearElements.length) {
+    return;
+  }
+
+  const currentYear = new Date().getFullYear();
+  yearElements.forEach((element) => {
+    element.textContent = currentYear;
+  });
+}
+
 async function initializeViewCounter() {
   const element = document.getElementById('view-count');
   if (!element) {
@@ -202,5 +214,6 @@ async function initializeViewCounter() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  updateCurrentYear();
   initializeViewCounter();
 });

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -72,6 +72,7 @@
     <p><a href="index.html">Return to Home</a></p>
   </div>
   <footer style="text-align: center; padding: 2em 0; color: #666;">
+    <p>© <span data-current-year></span> DECAL Lab, UC Davis. Released under MIT License.</p>
     <p><strong>Website Views:</strong> <span id="view-count">--</span></p>
   </footer>
   <script id="view-counter-script" src="./static/js/view-counter.js" data-api-base="https://ossprey.ngrok.app"></script>


### PR DESCRIPTION
## Summary
- add copyright messaging to page footers with spans for the current year
- update the shared view-counter script to populate footer years automatically across pages

## Testing
- Not run (not requested)