### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,17 @@
       </a>
     </div>
 
+    <div class="navbar-end pr-5">
+      <div class="navbar-item">
+        <button id="theme-toggle" class="button is-rounded is-light theme-toggle">
+          <span class="icon">
+            <i class="fas fa-moon"></i>
+          </span>
+          <span class="toggle-label">Dark</span>
+        </button>
+      </div>
+    </div>
+
   </div>
 </nav>
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,5 +1,7 @@
 body {
   font-family: 'Noto Sans', sans-serif;
+  background-color: #f9f9f9;
+  color: #1f1f1f;
 }
 
 
@@ -154,4 +156,100 @@ body {
 }
 #interpolation-image-wrapper img {
   border-radius: 5px;
+}
+
+.theme-toggle {
+  font-weight: 600;
+  min-width: 110px;
+  justify-content: center;
+}
+
+body.dark-mode {
+  background-color: #0f1117;
+  color: #e8e8e8;
+}
+
+body.dark-mode .hero,
+body.dark-mode .hero-body,
+body.dark-mode .section,
+body.dark-mode .navbar,
+body.dark-mode footer,
+body.dark-mode .container {
+  background-color: #0f1117;
+}
+
+body.dark-mode .navbar {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+body.dark-mode .navbar-item,
+body.dark-mode .navbar-link,
+body.dark-mode .navbar-brand .navbar-burger {
+  color: #e8e8e8;
+}
+
+body.dark-mode .navbar-burger span {
+  background-color: #e8e8e8;
+}
+
+body.dark-mode .navbar-dropdown {
+  background-color: #161925;
+  border-color: #2c3244;
+}
+
+body.dark-mode .navbar-item:hover,
+body.dark-mode .navbar-link:hover,
+body.dark-mode .navbar-dropdown .navbar-item:hover {
+  background-color: #1f2433;
+}
+
+body.dark-mode a {
+  color: #8ab4f8;
+}
+
+body.dark-mode a:hover {
+  color: #cbd8ff;
+}
+
+body.dark-mode table {
+  background-color: #161925;
+}
+
+body.dark-mode .table th,
+body.dark-mode .table td {
+  color: #e8e8e8;
+  border-color: #2c3244;
+}
+
+body.dark-mode .table.is-striped tbody tr:not(.is-selected):nth-child(2n) {
+  background-color: #1c2030;
+}
+
+body.dark-mode code {
+  background-color: #1f2433;
+  color: #d8dee9;
+}
+
+body.dark-mode .content h1,
+body.dark-mode .content h2,
+body.dark-mode .content h3,
+body.dark-mode .content h4,
+body.dark-mode .content h5,
+body.dark-mode .content h6,
+body.dark-mode .title,
+body.dark-mode .subtitle {
+  color: #f3f4f6;
+}
+
+body.dark-mode .button.is-light {
+  background-color: #242b3a;
+  color: #f2f2f2;
+  border-color: #2e374a;
+}
+
+body.dark-mode .button.is-dark,
+body.dark-mode .button.is-dark:hover {
+  background-color: #4a5368;
+  color: #0f1117;
+  border-color: #4a5368;
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -19,6 +19,45 @@ function setInterpolationImage(i) {
   $('#interpolation-image-wrapper').empty().append(image);
 }
 
+function updateThemeToggle(theme) {
+  var icon = $('#theme-toggle i');
+  var label = $('#theme-toggle .toggle-label');
+  var button = $('#theme-toggle');
+
+  if (theme === 'dark') {
+    icon.removeClass('fa-moon').addClass('fa-sun');
+    label.text('Light');
+    button.removeClass('is-light').addClass('is-dark');
+  } else {
+    icon.removeClass('fa-sun').addClass('fa-moon');
+    label.text('Dark');
+    button.removeClass('is-dark').addClass('is-light');
+  }
+}
+
+function setTheme(theme) {
+  if (theme === 'dark') {
+    $('body').addClass('dark-mode');
+  } else {
+    $('body').removeClass('dark-mode');
+  }
+  updateThemeToggle(theme);
+}
+
+function initializeTheme() {
+  var storedTheme = localStorage.getItem('ossprey-theme');
+  var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+  setTheme(initialTheme);
+
+  $('#theme-toggle').on('click', function() {
+    var currentTheme = $('body').hasClass('dark-mode') ? 'dark' : 'light';
+    var nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    setTheme(nextTheme);
+    localStorage.setItem('ossprey-theme', nextTheme);
+  });
+}
+
 
 $(document).ready(function() {
     // Check for click events on the navbar burger icon
@@ -74,5 +113,7 @@ $(document).ready(function() {
     $('#interpolation-slider').prop('max', NUM_INTERP_FRAMES - 1);
 
     bulmaSlider.attach();
+
+    initializeTheme();
 
 })


### PR DESCRIPTION
## Summary
- add a navbar toggle to switch between light and dark themes
- implement theme persistence with localStorage and system preference detection
- style dark mode across navigation, content, tables, and buttons for readability

## Testing
- Manual confirmation in the browser