### PR TITLE
Add light mode styling and toggle support

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,57 @@
       transition: background-color 0.3s ease, color 0.3s ease;
     }
 
+    body.light-mode {
+      background-color: #ffffff;
+      color: #111827;
+    }
+
+    body.light-mode a {
+      color: #1d4ed8;
+    }
+
+    body.light-mode .navbar,
+    body.light-mode .navbar-menu,
+    body.light-mode .hero,
+    body.light-mode .section,
+    body.light-mode .footer {
+      background-color: #ffffff;
+      color: #111827;
+    }
+
+    body.light-mode .navbar-item,
+    body.light-mode .navbar-link {
+      color: #111827;
+    }
+
+    body.light-mode .navbar-burger span {
+      background-color: #111827;
+    }
+
+    body.light-mode .navbar-dropdown {
+      background-color: #ffffff;
+      border: 1px solid #e5e7eb;
+    }
+
+    body.light-mode .navbar-dropdown .navbar-item:hover {
+      background-color: #f3f4f6;
+    }
+
+    body.light-mode .box,
+    body.light-mode .notification,
+    body.light-mode .table,
+    body.light-mode pre,
+    body.light-mode code {
+      background-color: #ffffff;
+      color: #111827;
+      border-color: #e5e7eb;
+    }
+
+    body.light-mode .table thead th,
+    body.light-mode .table tbody td {
+      border-color: #e5e7eb;
+    }
+
     /* --- Dark mode theme (shared palette with RepoWise site) --- */
     body.dark-mode {
       background-color: #020617; /* slate-950 */
@@ -197,7 +248,7 @@
 
   </style>
 </head>
-<body>
+<body class="light-mode">
 
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -4,6 +4,53 @@ body {
   color: #1f1f1f;
 }
 
+body.light-mode {
+  background-color: #f9f9f9;
+  color: #1f1f1f;
+}
+
+body.light-mode .hero,
+body.light-mode .hero-body,
+body.light-mode .section,
+body.light-mode .navbar,
+body.light-mode footer,
+body.light-mode .container {
+  background-color: #ffffff;
+}
+
+body.light-mode .navbar {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+body.light-mode .navbar-item,
+body.light-mode .navbar-link,
+body.light-mode .navbar-brand .navbar-burger {
+  color: #1f1f1f;
+}
+
+body.light-mode .navbar-burger span {
+  background-color: #1f1f1f;
+}
+
+body.light-mode .navbar-dropdown {
+  background-color: #ffffff;
+  border-color: #e5e7eb;
+}
+
+body.light-mode .navbar-item:hover,
+body.light-mode .navbar-link:hover,
+body.light-mode .navbar-dropdown .navbar-item:hover {
+  background-color: #f2f2f2;
+}
+
+body.light-mode a {
+  color: #1a73e8;
+}
+
+body.light-mode a:hover {
+  color: #0f3c68;
+}
+
 
 .footer .icon-link {
     font-size: 25px;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -26,20 +26,20 @@ function updateThemeToggle(theme) {
 
   if (theme === 'dark') {
     icon.removeClass('fa-moon').addClass('fa-sun');
-    label.text('Light');
+    label.text('Switch to Light');
     button.removeClass('is-light').addClass('is-dark');
   } else {
     icon.removeClass('fa-sun').addClass('fa-moon');
-    label.text('Dark');
+    label.text('Switch to Dark');
     button.removeClass('is-dark').addClass('is-light');
   }
 }
 
 function setTheme(theme) {
   if (theme === 'dark') {
-    $('body').addClass('dark-mode');
+    $('body').addClass('dark-mode').removeClass('light-mode');
   } else {
-    $('body').removeClass('dark-mode');
+    $('body').addClass('light-mode').removeClass('dark-mode');
   }
   updateThemeToggle(theme);
 }


### PR DESCRIPTION
## Summary
- add explicit light-mode styles for navigation, sections, and content elements
- default the page to light mode and clarify the toggle button text
- update the theme toggle logic to switch between light and dark mode classes

## Testing
- Not run (static site changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ffabc4184832a9a52ed8590e1586f)