### PR TITLE
Fix dark dropdown hover and improve theme toggle icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,10 @@
       background-color: #111827;
     }
 
+    body.dark-mode .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+      background-color: #111827;
+    }
+
     body.dark-mode .box {
       background-color: #020617;
       color: #e5e7eb;
@@ -328,7 +332,7 @@
       <div class="navbar-item">
         <button id="theme-toggle" class="button is-rounded is-light theme-toggle">
           <span class="icon">
-            <i class="fas fa-moon"></i>
+            <i class="fa-solid fa-moon"></i>
           </span>
           <span class="toggle-label">Dark</span>
         </button>

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -250,6 +250,10 @@ body.dark-mode .navbar-dropdown .navbar-item:hover {
   background-color: #1f2433;
 }
 
+body.dark-mode .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+  background-color: #1f2433;
+}
+
 body.dark-mode a {
   color: #8ab4f8;
 }


### PR DESCRIPTION
## Summary
- ensure dark-mode dropdown triggers use a dark hover background instead of white
- update the theme toggle button icon to use the solid Font Awesome style

## Testing
- not run (not requested)