### PR TITLE
Use local Font Awesome assets for offline rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,22 +14,14 @@
   <link rel="stylesheet" href="./static/css/bulma.min.css">
   <link rel="stylesheet" href="./static/css/bulma-carousel.min.css">
   <link rel="stylesheet" href="./static/css/bulma-slider.min.css">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        integrity="sha512-M9Aq7Dn0O2/kZLk93I7DiIP9N6byN1Nsx3Rp3XIanFkFJxuxMxDPZWS9Vyuk3F7S3Uz7Dnk3a1JpN96K8VZ0Yg=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="./static/css/fontawesome.all.min.css">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
   <link rel="stylesheet" href="./static/css/index.css">
   <link rel="icon" href="./static/images/favicon.ico">
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script defer
-          src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/js/all.min.js"
-          integrity="sha512-cjRKhC21JzP4gkI2Vq6KYFAsktwVDqveufqdpypu32n7Z1xXLSMNHYsYvwdivgLPgAvFp8ZUBKbjDgq09NDMpg=="
-          crossorigin="anonymous"
-          referrerpolicy="no-referrer"></script>
+  <script defer src="./static/js/fontawesome.all.min.js"></script>
   <script src="./static/js/bulma-carousel.min.js"></script>
   <script src="./static/js/bulma-slider.min.js"></script>
   <script src="./static/js/index.js"></script>


### PR DESCRIPTION
## Summary
- load Font Awesome CSS and JS from the repository’s local static assets instead of the external CDN to keep icons visible offline or when CDN is blocked

## Testing
- not run (not requested)