### PR TITLE
Fix Font Awesome icon classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
     <div class="navbar-start" style="flex-grow: 1; justify-content: center;">
       <a class="navbar-item" href="https://decallab.cs.ucdavis.edu/" target="_blank">
       <span class="icon">
-          <i class="fa-solid fa-home"></i>
+          <i class="fas fa-home"></i>
       </span>
       </a>
 
@@ -373,7 +373,7 @@
 
       <a class="navbar-item" href="#User-Guide">
         <span class="icon">
-          <i class="fa-solid fa-book-open"></i>
+          <i class="fas fa-book-open"></i>
         </span>
         <span>User Guide</span>
       </a>
@@ -383,7 +383,7 @@
       <div class="navbar-item">
         <button id="theme-toggle" class="button is-rounded is-light theme-toggle">
           <span class="icon">
-            <i class="fa-solid fa-moon"></i>
+            <i class="fas fa-moon"></i>
           </span>
           <span class="toggle-label">Dark</span>
         </button>
@@ -398,43 +398,43 @@
     <div class="sticky-nav-buttons">
       <a href="https://ossprey.netlify.app" target="_blank" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-solid fa-rocket"></i>
+          <i class="fas fa-rocket"></i>
         </span>
         <span>Live</span>
       </a>
       <a href="https://github.com/OSS-PREY" target="_blank" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-brands fa-github"></i>
+          <i class="fab fa-github"></i>
         </span>
         <span>Code</span>
       </a>
       <a href="https://zenodo.org/records/15307373" target="_blank" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-solid fa-images"></i>
+          <i class="fas fa-images"></i>
         </span>
         <span>Data</span>
       </a>
       <a href="#API" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-solid fa-code"></i>
+          <i class="fas fa-code"></i>
         </span>
         <span>API Endpoints</span>
       </a>
       <a href="#Features" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-solid fa-list"></i>
+          <i class="fas fa-list"></i>
         </span>
         <span>Features</span>
       </a>
       <a href="#Installation" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-solid fa-screwdriver-wrench"></i>
+          <i class="fas fa-screwdriver-wrench"></i>
         </span>
         <span>Install</span>
       </a>
       <a href="#Docker" class="button is-normal is-rounded is-dark">
         <span class="icon">
-          <i class="fa-brands fa-docker"></i>
+          <i class="fab fa-docker"></i>
         </span>
         <span>Docker</span>
       </a>
@@ -484,7 +484,7 @@
                 <a href="https://ossprey.netlify.app" target="_blank"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                    <i class="fa-solid fa-rocket"></i>
+                    <i class="fas fa-rocket"></i>
                   </span>
                   <span>Live</span>
                 </a>
@@ -494,7 +494,7 @@
                 <a href="https://github.com/OSS-PREY" target="_blank"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                      <i class="fa-brands fa-github"></i>
+                      <i class="fab fa-github"></i>
                   </span>
                   <span>Code</span>
                   </a>
@@ -504,7 +504,7 @@
                 <a href="https://zenodo.org/records/15307373" target="_blank"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                      <i class="fa-solid fa-images"></i>
+                      <i class="fas fa-images"></i>
                   </span>
                   <span>Data</span>
                   </a>
@@ -514,7 +514,7 @@
                 <a href="#API"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                      <i class="fa-solid fa-code"></i>
+                      <i class="fas fa-code"></i>
                   </span>
                   <span>API Endpoints</span>
                   </a>
@@ -524,7 +524,7 @@
                 <a href="#Features"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                      <i class="fa-solid fa-list"></i>
+                      <i class="fas fa-list"></i>
                   </span>
                   <span>Features</span>
                   </a>
@@ -534,7 +534,7 @@
                 <a href="#Installation"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                      <i class="fa-solid fa-screwdriver-wrench"></i>
+                      <i class="fas fa-screwdriver-wrench"></i>
                   </span>
                   <span>Install</span>
                   </a>
@@ -544,7 +544,7 @@
                 <a href="#Docker"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
-                    <i class="fa-brands fa-docker"></i>
+                    <i class="fab fa-docker"></i>
                   </span>
                   <span>Docker</span>
                   </a>
@@ -726,7 +726,7 @@
     <div class="columns is-centered has-text-centered">
       <div class="column is-four-fifths">
         <h2 class="title is-3">
-          <i class="fa-solid fa-code"></i> API Endpoints
+          <i class="fas fa-code"></i> API Endpoints
         </h2>
         <div class="content has-text-justified">
           <table class="table is-striped is-fullwidth">
@@ -818,7 +818,7 @@
     <div class="columns is-centered has-text-centered">
       <div class="column is-four-fifths">
         <h2 class="title is-3">
-          <i class="fa-solid fa-book"></i> User Guide
+          <i class="fas fa-book"></i> User Guide
         </h2>
         <div class="content has-text-justified">
           <p>This guide walks you through each element of the OSSPREY dashboard and explains how it contributes to understanding project sustainability.</p>
@@ -853,7 +853,7 @@
     <div class="columns is-centered has-text-centered">
       <div class="column is-four-fifths">
         <h2 class="title is-3">
-          <i class="fa-solid fa-screwdriver-wrench"></i> Installation Manual
+          <i class="fas fa-screwdriver-wrench"></i> Installation Manual
         </h2>
         <div class="content has-text-justified">
 
@@ -1016,7 +1016,7 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
     <div class="columns is-centered has-text-centered">
       <div class="column is-four-fifths">
         <h2 class="title is-3">
-          <i class="fa-brands fa-docker"></i> Docker Installation Manual
+          <i class="fab fa-docker"></i> Docker Installation Manual
         </h2>
 
         <p class="has-text-justified">
@@ -1206,7 +1206,7 @@ MONGODB_URI="mongodb://ossprey-backend:FL3YyVGCr79xlPT0@localhost:27017/decal-db
   <div class="container">
     <div class="content has-text-centered">
       <a class="icon-link" href="https://github.com/nafiz43" class="external-link" disabled>
-        <i class="fa-brands fa-github"></i>
+        <i class="fab fa-github"></i>
       </a>
     </div>
     <div class="columns is-centered">


### PR DESCRIPTION
## Summary
- switch homepage icon markup to the Font Awesome 5 classes included in the site assets
- ensure navigation, sticky section buttons, and headings render their intended icons again

## Testing
- Manual: Viewed the homepage locally via `python -m http.server` to confirm icons render correctly (see screenshot in artifacts/icon-fix.png)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c8b04a28832aabb68bf09e9a3ce2)